### PR TITLE
Reproducible Issue with rust toolchain in external pigweed repo

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -24,6 +24,7 @@ bazel_dep(name = "platforms", version = "0.0.10")
 bazel_dep(name = "pw_toolchain")
 bazel_dep(name = "rules_cc")
 bazel_dep(name = "rules_python", version = "0.34.0")
+bazel_dep(name = "rules_rust", version = "0.45.1")
 
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,0 +1,11 @@
+load(
+    "@pigweed//pw_toolchain/rust:defs.bzl",
+    "pw_rust_register_toolchain_and_target_repos",
+    "pw_rust_register_toolchains",
+)
+
+CIPD_TAG = "rust_revision:bf9c7a64ad222b85397573668b39e6d1ab9f4a72"
+pw_rust_register_toolchain_and_target_repos(
+    cipd_tag = CIPD_TAG,
+)
+pw_rust_register_toolchains()

--- a/tools/BUILD.bazel
+++ b/tools/BUILD.bazel
@@ -13,6 +13,7 @@
 # the License.
 
 load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+load("@rules_rust//rust:defs.bzl", "rust_library")
 
 package(default_visibility = ["//visibility:public"])
 
@@ -71,4 +72,10 @@ py_binary(
         ":sense_lib",
         "@pigweed//pw_cli/py:pw_cli",
     ],
+)
+
+
+rust_library(
+    name = "lib",
+    srcs = ["lib.rs"],
 )

--- a/tools/lib.rs
+++ b/tools/lib.rs
@@ -1,0 +1,24 @@
+pub struct Greeter {
+    greeting: String,
+}
+
+impl Greeter {
+    pub fn new(greeting: &str) -> Greeter {
+        Greeter { greeting: greeting.to_string(), }
+    }
+
+    pub fn greet(&self, thing: &str) -> String {
+        format!("{} {}", &self.greeting, thing)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::Greeter;
+
+    #[test]
+    fn test_greeting() {
+        let hello = Greeter::new("Hi");
+        assert_eq!("Hi Rust", hello.greet("Rust"));
+    }
+}


### PR DESCRIPTION
Reproduce by running:

```
bazel build //tools:lib --toolchain_resolution_debug="@@rules_rust~//rust:toolchain_type"
```

Note that default fails to work because of the clang CPP toolchain. Registering the toolchain in `WORKSPACE` gets it selected, but then ends up with:

```
INFO: ToolchainResolution: Target platform @@platforms//host:host: Selected execution platform @@platforms//host:host, type @@rules_rust~//rust:toolchain_type -> toolchain @@pigweed~//pw_toolchain/rust:host_rust_toolchain_linux_x86_64_stable_rust_toolchain, type @@bazel_tools//tools/cpp:toolchain_type -> toolchain @@pigweed~//pw_toolchain/host_clang:host_toolchain
ERROR: no such package '@@[unknown repo 'rust_toolchain_host_linux_x86_64' requested from @@pigweed~]//': The repository '@@[unknown repo 'rust_toolchain_host_linux_x86_64' requested from @@pigweed~]' could not be resolved: No repository visible as '@rust_toolchain_host_linux_x86_64' from repository '@@pigweed~'
ERROR: /home/mchristen/.local/tmp/bazel/_bazel_mchristen/fe66862a52f25f8003207d6b27dc05b6/external/pigweed~/pw_toolchain/rust/BUILD.bazel:22:34: no such package '@@[unknown repo 'rust_toolchain_host_linux_x86_64' requested from @@pigweed~]//': The repository '@@[unknown repo 'rust_toolchain_host_linux_x86_64' requested from @@pigweed~]' could not be resolved: No repository visible as '@rust_toolchain_host_linux_x86_64' from repository '@@pigweed~' and referenced by '@@pigweed~//pw_toolchain/rust:host_rust_toolchain_linux_x86_64_stable_rust_toolchain'
ERROR: Analysis of target '//tools:lib' failed; build aborted: Analysis failed
```